### PR TITLE
Gaussian Blur Fix

### DIFF
--- a/src/algos/gaussian_blur.py
+++ b/src/algos/gaussian_blur.py
@@ -21,7 +21,7 @@ class GaussianSmoothing(nn.Module):
     def __init__(self, channels, kernel_size, sigma, device, dim=2):
         super(GaussianSmoothing, self).__init__()
         if isinstance(kernel_size, numbers.Number):
-            kernel_size = [kernel_size] * dim
+            kernel_size = [kernel_size*math.sqrt(sigma)] * dim
         if isinstance(sigma, numbers.Number):
             sigma = [sigma] * dim
 


### PR DESCRIPTION
Before this edit was made, the kernel size would not scale with sigma's size which is necessary for the algorithm to work properly. Sqrt(sigma) is a somewhat arbitrary scaling factor, however, the square root function was chosen because it prevents the kernel size from getting too big too fast. One could theoretically scale the kernel size with sigma using any function as long as the size is positive, however, this will affect how kernel size scales and may prohibit you from experimenting with larger values of sigma since kernel size is restricted by the size of the data.